### PR TITLE
refactor(footer): improve layout and content

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,24 +3,24 @@ import Link from "next/link";
 export function Footer() {
   return (
     <footer className="shadow-2xl rounded-t-2xl mt-12 border-t border-white/10 bg-white/30 dark:bg-[rgba(24,28,40,0.18)] backdrop-blur-xl">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-4">
           <div className="flex items-center space-x-2 text-sm text-foreground/80">
             <span className="font-mono">
-              <span className="text-primary">{"$>"}</span> ./made with{' '}<span className="text-red-500 mx-1">{"<3"}{' '}</span>by{' '}
+              <span className="text-primary">{"$>"}</span> ./made with{' '}<span className="text-red-500 mx-1">{"<3"}{' '}</span>on{' '}
               <Link
-                href="https://github.com/pquline"
+                href="https://github.com/pquline/ft_dashboard"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-foreground hover:underline transition-colors duration-200 group inline-flex items-center gap-1"
               >
-                <span>pquline</span>
+                <span>GitHub</span>
               </Link>
               <span className="text-yellow-500 animate-pulse">{" █"}</span>
             </span>
           </div>
 
-          {/* <div className="flex items-center space-x-6 text-sm">
+          <div className="flex items-center space-x-4 sm:space-x-6 text-sm">
             <Link
               href="/legal/privacy"
               className="text-foreground/90 hover:text-primary transition-colors duration-200"
@@ -33,7 +33,7 @@ export function Footer() {
             >
               Terms
             </Link>
-          </div> */}
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- Change text from 'made with <3 by pquline' to 'made with <3 on GitHub'
- Update GitHub link to point to ft_dashboard repository
- Make Privacy and Terms links visible again (uncommented)
- Improve mobile layout: reduce vertical padding (py-4 sm:py-6)
- Improve responsive breakpoints: sm instead of md for better mobile experience
- Reduce gap spacing on mobile (gap-3 sm:gap-4) for more compact layout
- Reduce link spacing on mobile (space-x-4 sm:space-x-6) for better fit