### PR TITLE
fix(progress): unify work and holiday hours in Total Hours progress bar

### DIFF
--- a/src/components/DashboardSummaryCards.tsx
+++ b/src/components/DashboardSummaryCards.tsx
@@ -210,17 +210,29 @@ export function DashboardSummaryCards({
               <span className="text-green-500">Work Hours</span>
               <span className="text-purple-500">Holiday Hours</span>
             </div>
-            <div className="w-full bg-muted/50 rounded-full h-2 flex overflow-hidden">
-              {/* Work Hours (Green) */}
-              <div
-                className="bg-gradient-to-r from-green-500 to-green-600 h-2 transition-all duration-500"
-                style={{ width: `${Math.min((totalMinutes / 60 / 140) * 100, 100)}%` }}
-              ></div>
-              {/* Holiday Hours (Purple) */}
-              <div
-                className="bg-gradient-to-r from-purple-500 to-purple-600 h-2 transition-all duration-500"
-                style={{ width: `${Math.min((holidayMinutes / 60 / 140) * 100, 100)}%` }}
-              ></div>
+                        <div className="w-full bg-muted/50 rounded-full h-2 flex overflow-hidden">
+              {(() => {
+                const workHours = totalMinutes / 60;
+                const holidayHoursActual = holidayMinutes / 60;
+                const totalProgressPercent = Math.min((totalHours / 140) * 100, 100);
+                const workPercent = totalHours > 0 ? (workHours / totalHours) * totalProgressPercent : 0;
+                const holidayPercent = totalHours > 0 ? (holidayHoursActual / totalHours) * totalProgressPercent : 0;
+
+                return (
+                  <>
+                    {/* Work Hours (Green) */}
+                    <div
+                      className="bg-gradient-to-r from-green-500 to-green-600 h-2 transition-all duration-500"
+                      style={{ width: `${workPercent}%` }}
+                    ></div>
+                    {/* Holiday Hours (Purple) */}
+                    <div
+                      className="bg-gradient-to-r from-purple-500 to-purple-600 h-2 transition-all duration-500"
+                      style={{ width: `${holidayPercent}%` }}
+                    ></div>
+                  </>
+                );
+              })()}
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
- Fixed progress bar calculation to be proportional to actual total hours vs 140h requirement
- Work and holiday segments now properly represent their relative contributions
- Progress bar fill is now correctly limited to actualHours/140 ratio
- Eliminated issue where segments could exceed 100% when combined
- Added clear logic with inline calculations for better maintainability

Example: 90h work + 10h holidays = 100h total shows 71.4% filled (90% work segment + 10% holiday segment within that 71.4%)

Fixes #50